### PR TITLE
PROD-697: Adapt to hidden flow option

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.github.pngme:android-sdk:2.0.4'
+    implementation 'com.github.pngme:android-sdk:hide-dialog-flow-SNAPSHOT'
     implementation 'com.squareup.moshi:moshi-kotlin:1.12.0'
     implementation 'androidx.work:work-runtime-ktx:2.7.1'
 

--- a/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
+++ b/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
@@ -64,10 +64,10 @@ class PermissionFragment : Fragment() {
                         user.phoneNumber,
                         "",
                         false,
-                        MainActivity.COMPANY_NAME
-                    ) {
-                        navigateToLoadApplication()
-                    }
+                        MainActivity.COMPANY_NAME,
+                        {navigateToLoadApplication()},
+                        true,
+                    )
                 }
             } else {
                 navigateToLoadApplication()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Acme Bank</string>
+    <string name="app_name">Acme Bank - Kotlin</string>
     <string name="bank_name">Acme Bank</string>
     <string name="splash_title">Welcome Acme Bank!</string>
     <!-- TODO: Remove or change this placeholder text -->


### PR DESCRIPTION
This is an example `diff` to see how to adapt the Kotlin code to the latest changes in our android-sdk to hide the pngme screen in the validation flow.