### PR TITLE
Bump Pngme SDK version to 7.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,11 +5,23 @@ plugins {
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
+import java.util.Properties
+
+// 1. Load local.properties
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    localProperties.load(new FileInputStream(localPropertiesFile))
+}
+
+// 2. Read your PNGME_SDK_TOKEN (defaults to empty string if absent)
+def pngmeToken = localProperties.getProperty("PNGME_SDK_TOKEN", "")
+
 android {
     namespace "com.example.samplekotlin"
     compileSdk 34
     buildToolsVersion "34.0.0"
-    
+
     defaultConfig {
         applicationId "com.example.samplekotlin"
         minSdk 19
@@ -20,6 +32,9 @@ android {
         multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        // 3. Inject into BuildConfig
+        buildConfigField "String", "PNGME_SDK_TOKEN", "\"${pngmeToken}\""
     }
 
     buildTypes {
@@ -43,7 +58,6 @@ android {
 }
 
 dependencies {
-
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation 'com.google.android.material:material:1.4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
     
     defaultConfig {
         applicationId "com.example.samplekotlin"
-        minSdk 16
+        minSdk 19
         targetSdk 34
         versionCode 1
         versionName "1.0"
@@ -51,7 +51,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.github.pngme:android-sdk:v6.0.1'
+    implementation 'com.github.pngme:android-sdk:v7.0.2'
     implementation 'com.squareup.moshi:moshi-kotlin:1.14.0'
     implementation 'androidx.work:work-runtime-ktx:2.7.1'
 

--- a/app/src/main/java/com/example/samplekotlin/Constants.kt
+++ b/app/src/main/java/com/example/samplekotlin/Constants.kt
@@ -2,6 +2,5 @@ package com.example.samplekotlin
 
 // in Constants.kt
 object Constants {
-    const val PNGME_CLIENT_KEY = "your_pngme_client_key_here"
     const val SHARED_PREF_NAME = "sample_app_preferences"
 }

--- a/app/src/main/java/com/example/samplekotlin/Constants.kt
+++ b/app/src/main/java/com/example/samplekotlin/Constants.kt
@@ -1,0 +1,7 @@
+package com.example.samplekotlin
+
+// in Constants.kt
+object Constants {
+    const val PNGME_CLIENT_KEY = "your_pngme_client_key_here"
+    const val SHARED_PREF_NAME = "sample_app_preferences"
+}

--- a/app/src/main/java/com/example/samplekotlin/SignUpActivity.kt
+++ b/app/src/main/java/com/example/samplekotlin/SignUpActivity.kt
@@ -9,11 +9,7 @@ import androidx.core.content.edit
 import com.example.samplekotlin.home.MainActivity
 import com.example.samplekotlin.model.User
 import com.squareup.moshi.JsonAdapter
-
 import com.squareup.moshi.Moshi
-
-
-
 
 class SignUpActivity : AppCompatActivity() {
 
@@ -41,7 +37,7 @@ class SignUpActivity : AppCompatActivity() {
         val jsonAdapter: JsonAdapter<User> = moshi.adapter(User::class.java)
         val json = jsonAdapter.toJson(userInfo)
 
-        val sharedPreferences = getSharedPreferences(BuildConfig.SHARED_PREF_NAME, MODE_PRIVATE)
+        val sharedPreferences = getSharedPreferences(Constants.SHARED_PREF_NAME, MODE_PRIVATE)
         sharedPreferences.edit {
             putString("userInfo", json)
             apply()

--- a/app/src/main/java/com/example/samplekotlin/SignUpActivity.kt
+++ b/app/src/main/java/com/example/samplekotlin/SignUpActivity.kt
@@ -13,10 +13,23 @@ import com.squareup.moshi.Moshi
 
 class SignUpActivity : AppCompatActivity() {
 
+    private lateinit var externalIdInput: EditText
+    private lateinit var firstNameInput: EditText
+    private lateinit var lastNameInput: EditText
+    private lateinit var emailInput: EditText
+    private lateinit var phoneInput: EditText
+
     override fun onCreate(savedInstanceState: Bundle?) {
         supportActionBar?.title = getString(R.string.bank_name)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_sign_up)
+
+        externalIdInput = findViewById(R.id.external_id_text)
+        firstNameInput  = findViewById(R.id.first_name_text)
+        lastNameInput   = findViewById(R.id.last_name_text)
+        emailInput      = findViewById(R.id.email_text)
+        phoneInput      = findViewById(R.id.phone_text)
+
         val createAccountButton = findViewById<Button>(R.id.create_account_button)
         createAccountButton.setOnClickListener {
             saveUserInputs()
@@ -27,10 +40,12 @@ class SignUpActivity : AppCompatActivity() {
     }
 
     private fun saveUserInputs() {
-        val externalId = findViewById<EditText>(R.id.external_id_text)
-
         val userInfo = User(
-            externalId.text.toString(),
+            externalId = externalIdInput.text.toString(),
+            firstName  = firstNameInput.text.toString(),
+            lastName   = lastNameInput.text.toString(),
+            email      = emailInput.text.toString(),
+            phoneNumber= phoneInput.text.toString()
         )
 
         val moshi = Moshi.Builder().build()

--- a/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
+++ b/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
@@ -8,7 +8,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.CheckBox
+import android.widget.RadioGroup
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.navigation.Navigation
@@ -37,27 +38,23 @@ class PermissionFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val styleGroup = view.findViewById<RadioGroup>(R.id.pngme_style_group)
         val continueButton = view.findViewById<Button>(R.id.next_button)
-        val usePngmeCheckBox = view.findViewById<CheckBox>(R.id.use_pngme_checkbox)
-        val customStyleCheckbox = view.findViewById<CheckBox>(
-            R.id.use_pngme_custom_style_checkbox
-        )
-        val pngmeChecked = wasPngmeChecked()
-        usePngmeCheckBox.isChecked = pngmeChecked
-        usePngmeCheckBox.isEnabled = !pngmeChecked
 
         continueButton.setOnClickListener {
-            // save state of checkBox
-            if (usePngmeCheckBox.isChecked) {
+            val checkedId = styleGroup.checkedRadioButtonId
+            if (checkedId == R.id.option_default_pngme || checkedId == R.id.option_custom_pngme) {
                 setPngmeAsChecked()
-                val mainActivity = (activity as MainActivity)
+                val mainActivity = requireActivity() as MainActivity
+
                 getUser()?.let { user ->
-                    // build a simple custom style example
+                    // build your custom style once
                     val customStyle = PngmeDialogStyle(
-                        primaryColor          = ContextCompat.getColor(requireContext(), R.color.purple_500),
-                        backgroundColor       = ContextCompat.getColor(requireContext(), R.color.white),
-                        textColor             = ContextCompat.getColor(requireContext(), R.color.black),
-                        buttonBackgroundColor = ContextCompat.getColor(requireContext(), R.color.teal_200),
+                        primaryColor          = ContextCompat.getColor(requireContext(), R.color.sample_custom_styling_primary),
+                        backgroundColor       = ContextCompat.getColor(requireContext(), R.color.sample_custom_styling_background),
+                        textColor             = ContextCompat.getColor(requireContext(), R.color.sample_custom_styling_text),
+                        buttonBackgroundColor = ContextCompat.getColor(requireContext(), R.color.sample_custom_styling_accent),
                         buttonTextColor       = ContextCompat.getColor(requireContext(), R.color.white),
                         titleTextSize         = 22f,
                         bodyTextSize          = 16f,
@@ -65,37 +62,38 @@ class PermissionFragment : Fragment() {
                         customButtonText      = "Let’s Go!"
                     )
 
-                    // choose overload depending on whether custom-style box is checked
-                    if (customStyleCheckbox.isChecked) {
-                        PngmeSdk.goWithCustomDialog(
-                            activity        = mainActivity,
-                            clientKey      = BuildConfig.PNGME_SDK_TOKEN,
-                            firstName      = user.firstName,
-                            lastName       = user.lastName,
-                            email          = user.email,
-                            phoneNumber    = user.phoneNumber,
-                            externalId     = user.externalId,
-                            companyName    = MainActivity.COMPANY_NAME,
-                            hasAcceptedTerms = true,
-                            onComplete     = { navigateToLoadApplication() },
-                            dialogStyle    = customStyle
+
+                    // choose overload
+                    if (checkedId == R.id.option_custom_pngme) {
+                        PngmeSdk.go(
+                            activity         = mainActivity,
+                            clientKey        = BuildConfig.PNGME_SDK_TOKEN,
+                            firstName        = user.firstName,
+                            lastName         = user.lastName,
+                            email            = user.email,
+                            phoneNumber      = user.phoneNumber,
+                            externalId       = user.externalId,
+                            companyName      = MainActivity.COMPANY_NAME,
+                            onComplete       = { navigateToLoadApplication() },
+                            dialogStyle      = customStyle
                         )
                     } else {
                         PngmeSdk.goWithCustomDialog(
-                            activity        = mainActivity,
-                            clientKey       = BuildConfig.PNGME_SDK_TOKEN,
-                            firstName       = user.firstName,
-                            lastName        = user.lastName,
-                            email           = user.email,
-                            phoneNumber     = user.phoneNumber,
-                            externalId      = user.externalId,
-                            companyName     = MainActivity.COMPANY_NAME,
-                            hasAcceptedTerms= true,
-                            onComplete      = { navigateToLoadApplication() }
+                            activity         = mainActivity,
+                            clientKey        = BuildConfig.PNGME_SDK_TOKEN,
+                            firstName        = user.firstName,
+                            lastName         = user.lastName,
+                            email            = user.email,
+                            phoneNumber      = user.phoneNumber,
+                            externalId       = user.externalId,
+                            companyName      = MainActivity.COMPANY_NAME,
+                            hasAcceptedTerms = true,
+                            onComplete       = { navigateToLoadApplication() }
                         )
                     }
                 }
             } else {
+                // no Pngme option selected
                 navigateToLoadApplication()
             }
         }

--- a/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
+++ b/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
@@ -51,12 +51,12 @@ class PermissionFragment : Fragment() {
                     PngmeSdk.goWithCustomDialog(
                         activity = mainActivity,
                         clientKey = BuildConfig.PNGME_SDK_TOKEN,
-                        firstName = "",
-                        lastName ="",
-                        email = "",
-                        phoneNumber = "",
-                        externalId = user.externalId,
-                        companyName = MainActivity.COMPANY_NAME,
+                        firstName    = user.firstName,
+                        lastName     = user.lastName,
+                        email        = user.email,
+                        phoneNumber  = user.phoneNumber,
+                        externalId   = user.externalId,
+                        companyName  = MainActivity.COMPANY_NAME,
                         hasAcceptedTerms = true, // set to true if user has given consent
                         onComplete = {
                             navigateToLoadApplication()

--- a/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
+++ b/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.CheckBox
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.navigation.Navigation
 import com.example.samplekotlin.BuildConfig
@@ -16,6 +17,7 @@ import com.example.samplekotlin.Constants
 import com.example.samplekotlin.R
 import com.example.samplekotlin.model.User
 import com.pngme.sdk.library.PngmeSdk
+import com.pngme.sdk.library.views.PngmeDialogStyle
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 
@@ -37,7 +39,9 @@ class PermissionFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         val continueButton = view.findViewById<Button>(R.id.next_button)
         val usePngmeCheckBox = view.findViewById<CheckBox>(R.id.use_pngme_checkbox)
-
+        val customStyleCheckbox = view.findViewById<CheckBox>(
+            R.id.use_pngme_custom_style_checkbox
+        )
         val pngmeChecked = wasPngmeChecked()
         usePngmeCheckBox.isChecked = pngmeChecked
         usePngmeCheckBox.isEnabled = !pngmeChecked
@@ -48,20 +52,48 @@ class PermissionFragment : Fragment() {
                 setPngmeAsChecked()
                 val mainActivity = (activity as MainActivity)
                 getUser()?.let { user ->
-                    PngmeSdk.goWithCustomDialog(
-                        activity = mainActivity,
-                        clientKey = BuildConfig.PNGME_SDK_TOKEN,
-                        firstName    = user.firstName,
-                        lastName     = user.lastName,
-                        email        = user.email,
-                        phoneNumber  = user.phoneNumber,
-                        externalId   = user.externalId,
-                        companyName  = MainActivity.COMPANY_NAME,
-                        hasAcceptedTerms = true, // set to true if user has given consent
-                        onComplete = {
-                            navigateToLoadApplication()
-                        }
+                    // build a simple custom style example
+                    val customStyle = PngmeDialogStyle(
+                        primaryColor          = ContextCompat.getColor(requireContext(), R.color.purple_500),
+                        backgroundColor       = ContextCompat.getColor(requireContext(), R.color.white),
+                        textColor             = ContextCompat.getColor(requireContext(), R.color.black),
+                        buttonBackgroundColor = ContextCompat.getColor(requireContext(), R.color.teal_200),
+                        buttonTextColor       = ContextCompat.getColor(requireContext(), R.color.white),
+                        titleTextSize         = 22f,
+                        bodyTextSize          = 16f,
+                        buttonTextSize        = 18f,
+                        customButtonText      = "Let’s Go!"
                     )
+
+                    // choose overload depending on whether custom-style box is checked
+                    if (customStyleCheckbox.isChecked) {
+                        PngmeSdk.goWithCustomDialog(
+                            activity        = mainActivity,
+                            clientKey      = BuildConfig.PNGME_SDK_TOKEN,
+                            firstName      = user.firstName,
+                            lastName       = user.lastName,
+                            email          = user.email,
+                            phoneNumber    = user.phoneNumber,
+                            externalId     = user.externalId,
+                            companyName    = MainActivity.COMPANY_NAME,
+                            hasAcceptedTerms = true,
+                            onComplete     = { navigateToLoadApplication() },
+                            dialogStyle    = customStyle
+                        )
+                    } else {
+                        PngmeSdk.goWithCustomDialog(
+                            activity        = mainActivity,
+                            clientKey       = BuildConfig.PNGME_SDK_TOKEN,
+                            firstName       = user.firstName,
+                            lastName        = user.lastName,
+                            email           = user.email,
+                            phoneNumber     = user.phoneNumber,
+                            externalId      = user.externalId,
+                            companyName     = MainActivity.COMPANY_NAME,
+                            hasAcceptedTerms= true,
+                            onComplete      = { navigateToLoadApplication() }
+                        )
+                    }
                 }
             } else {
                 navigateToLoadApplication()

--- a/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
+++ b/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
@@ -52,13 +52,18 @@ class PermissionFragment : Fragment() {
                 getUser()?.let { user ->
                     PngmeSdk.goWithCustomDialog(
                         activity = mainActivity,
-                        clientKey = BuildConfig.PNGME_SDK_TOKEN,
+                        clientKey = PNGME_CLIENT_KEY,
+                        firstName = "",
+                        lastName ="",
+                        email = "",
+                        phoneNumber = "",
                         externalId = user.externalId,
-                        companyName = MainActivity.COMPANY_NAME
+                        companyName = MainActivity.COMPANY_NAME,
                         hasAcceptedTerms = true, // set to true if user has given consent
-                    ) {
-                        navigateToLoadApplication()
-                    }
+                        onComplete = {
+                            navigateToLoadApplication()
+                        }
+                    )
                 }
             } else {
                 navigateToLoadApplication()
@@ -97,4 +102,8 @@ class PermissionFragment : Fragment() {
         }
     }
 
+    companion object {
+        // Add your Pngme SDK token here
+        private const val PNGME_CLIENT_KEY = "your_pngme_client_key_here"
+    }
 }

--- a/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
+++ b/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
@@ -11,6 +11,7 @@ import android.widget.Button
 import android.widget.CheckBox
 import androidx.core.content.edit
 import androidx.navigation.Navigation
+import com.example.samplekotlin.BuildConfig
 import com.example.samplekotlin.Constants
 import com.example.samplekotlin.R
 import com.example.samplekotlin.model.User
@@ -49,7 +50,7 @@ class PermissionFragment : Fragment() {
                 getUser()?.let { user ->
                     PngmeSdk.goWithCustomDialog(
                         activity = mainActivity,
-                        clientKey = Constants.PNGME_CLIENT_KEY,
+                        clientKey = BuildConfig.PNGME_SDK_TOKEN,
                         firstName = "",
                         lastName ="",
                         email = "",

--- a/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
+++ b/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
@@ -2,8 +2,6 @@ package com.example.samplekotlin.home
 
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
-import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -11,10 +9,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.CheckBox
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.navigation.Navigation
-import com.example.samplekotlin.BuildConfig
+import com.example.samplekotlin.Constants
 import com.example.samplekotlin.R
 import com.example.samplekotlin.model.User
 import com.pngme.sdk.library.PngmeSdk
@@ -52,7 +49,7 @@ class PermissionFragment : Fragment() {
                 getUser()?.let { user ->
                     PngmeSdk.goWithCustomDialog(
                         activity = mainActivity,
-                        clientKey = PNGME_CLIENT_KEY,
+                        clientKey = Constants.PNGME_CLIENT_KEY,
                         firstName = "",
                         lastName ="",
                         email = "",
@@ -90,7 +87,7 @@ class PermissionFragment : Fragment() {
 
     private fun getSharedPreference(): SharedPreferences? {
         return activity?.getSharedPreferences(
-            BuildConfig.SHARED_PREF_NAME,
+            Constants.SHARED_PREF_NAME,
             MODE_PRIVATE
         )
     }
@@ -100,10 +97,5 @@ class PermissionFragment : Fragment() {
             Navigation.findNavController(it)
                 .navigate(R.id.action_permissionFragment_to_loanApplicationFragment)
         }
-    }
-
-    companion object {
-        // Add your Pngme SDK token here
-        private const val PNGME_CLIENT_KEY = "your_pngme_client_key_here"
     }
 }

--- a/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
+++ b/app/src/main/java/com/example/samplekotlin/home/PermissionFragment.kt
@@ -59,7 +59,7 @@ class PermissionFragment : Fragment() {
                         titleTextSize         = 22f,
                         bodyTextSize          = 16f,
                         buttonTextSize        = 18f,
-                        customButtonText      = "Let’s Go!"
+                        customButtonText      = "Accept"
                     )
 
 

--- a/app/src/main/java/com/example/samplekotlin/model/User.kt
+++ b/app/src/main/java/com/example/samplekotlin/model/User.kt
@@ -5,4 +5,8 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class User(
     val externalId: String,
+    val firstName: String,
+    val lastName: String,
+    val email: String,
+    val phoneNumber: String
 )

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -36,6 +36,57 @@
                 android:layout_marginTop="6dp"
                 android:hint="external id" />
 
+            <!-- First Name -->
+            <TextView
+                android:layout_marginTop="16dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="First Name" />
+            <EditText
+                android:id="@+id/first_name_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="First name" />
+
+            <!-- Last Name -->
+            <TextView
+                android:layout_marginTop="16dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Last Name" />
+            <EditText
+                android:id="@+id/last_name_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Last name" />
+
+            <!-- Email -->
+            <TextView
+                android:layout_marginTop="16dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Email" />
+            <EditText
+                android:id="@+id/email_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textEmailAddress"
+                android:hint="you@example.com" />
+
+            <!-- Phone Number -->
+            <TextView
+                android:layout_marginTop="16dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Phone Number" />
+            <EditText
+                android:id="@+id/phone_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="phone"
+                android:hint="+254734567890" />
+
+            <!-- Create account -->
 
             <Button
                 android:id="@+id/create_account_button"

--- a/app/src/main/res/layout/fragment_permission.xml
+++ b/app/src/main/res/layout/fragment_permission.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".home.PermissionFragment">
 
-    <!-- TODO: Update blank fragment layout -->
     <TextView
         android:id="@+id/optional_text"
         android:layout_width="match_parent"
@@ -49,6 +49,15 @@
             android:textSize="20sp"
             android:layout_marginTop="20dp"
             android:text="Use Pngme"/>
+
+        <!-- New: Use Pngme with custom styling -->
+        <CheckBox
+            android:id="@+id/use_pngme_custom_style_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="20sp"
+            android:layout_marginTop="20dp"
+            android:text="Use Pngme with custom styling"/>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_permission.xml
+++ b/app/src/main/res/layout/fragment_permission.xml
@@ -42,23 +42,27 @@
             android:layout_marginTop="20dp"
             android:text="Receive promotions"/>
 
-        <CheckBox
-            android:id="@+id/use_pngme_checkbox"
+        <RadioGroup
+            android:id="@+id/pngme_style_group"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="20sp"
-            android:layout_marginTop="20dp"
-            android:text="Use Pngme"/>
+            android:orientation="vertical"
+            android:layout_marginTop="20dp">
 
-        <!-- New: Use Pngme with custom styling -->
-        <CheckBox
-            android:id="@+id/use_pngme_custom_style_checkbox"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="20sp"
-            android:layout_marginTop="20dp"
-            android:text="Use Pngme with custom styling"/>
+            <RadioButton
+                android:id="@+id/option_default_pngme"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Use Pngme (default styling)"
+                android:textSize="20sp"/>
 
+            <RadioButton
+                android:id="@+id/option_custom_pngme"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Use Pngme with custom styling"
+                android:textSize="20sp"/>
+        </RadioGroup>
     </LinearLayout>
 
     <Button

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,10 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="sample_custom_styling_primary">#0288D1</color>
+    <color name="sample_custom_styling_secondary">#26C6DA </color>
+    <color name="sample_custom_styling_accent">#FFD54F</color>
+    <color name="sample_custom_styling_background">#E1F5FE</color>
+    <color name="sample_custom_styling_text">#263238</color>
+
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10'
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,10 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 --illegal-access=permit
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 
+  # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK


### PR DESCRIPTION
### Changes

**Dependency**: Upgrade com.github.pngme:android-sdk to v7.0.2

**UI**: Add “Use Pngme with custom styling” option on Permissions screen

**Styling**: Introduce Serene Ocean color resources (sample_custom_styling_*)

**Code**: Build and pass a PngmeDialogStyle to go(...) when custom styling is selected

## Screenshots

<!-- Custom-styled Pngme dialog (Serene Ocean palette) -->
<p align="center">
  <img src="https://github.com/user-attachments/assets/779d261a-5a21-4b13-b1a2-d986eca3e9da" width="400" alt="Custom Serene Ocean Dialog"/><br/>
  <em>Custom Serene Ocean styling applied</em>
</p>